### PR TITLE
Add zod as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-tsdoc": "^0.4.0",
     "whatwg-fetch": "^3.6.20"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "zod": "^3.25.56"
   },
   "resolutions": {


### PR DESCRIPTION
Optional dependencies are installed by default if conditions are met. Including zod as a peer dependency lets the user decide if they want to install it or not.