### PR TITLE
refactor: improve congress entity types

### DIFF
--- a/src/clients/congress.e2e.test.ts
+++ b/src/clients/congress.e2e.test.ts
@@ -1,5 +1,5 @@
 import { CongressClient } from './congress';
-import { ListCongressSchema, CongressSchema } from '../schemas/congress';
+import { CongressSummarySchema, CongressSchema } from '../schemas/congress';
 
 const API_KEY = process.env.CONGRESS_GOV_API_KEY || '';
 
@@ -18,7 +18,7 @@ describe('CongressClient Integration Tests', () => {
       expect(congresses.length).toBeLessThanOrEqual(5);
 
       congresses.forEach((congress) => {
-        expect(ListCongressSchema.parse(congress));
+        expect(CongressSummarySchema.parse(congress));
       });
     });
   });

--- a/src/clients/congress.ts
+++ b/src/clients/congress.ts
@@ -1,6 +1,6 @@
 import { BaseClient } from './base';
 import type { PaginationParams, PaginatedResponse, BaseParams } from '../types';
-import type { ListCongress, Congress } from '../schemas/congress';
+import type { CongressSummary, Congress } from '../schemas/congress';
 
 export class CongressClient extends BaseClient {
   constructor({ apiKey }: { apiKey: string }) {
@@ -13,7 +13,7 @@ export class CongressClient extends BaseClient {
    * @returns A list of congresses and their sessions
    */
   async getCongresses(params: PaginationParams = {}) {
-    return this.get<PaginatedResponse<{ congresses: ListCongress[] }>>('', params);
+    return this.get<PaginatedResponse<{ congresses: CongressSummary[] }>>('', params);
   }
 
   /**

--- a/src/schemas/congress.ts
+++ b/src/schemas/congress.ts
@@ -1,14 +1,16 @@
 import { z } from 'zod';
+import { CongressChamber, Session } from './constants';
 
-export const ListCongressSchema = z.strictObject({
+
+export const CongressSummarySchema = z.strictObject({
   startYear: z.string(),
   name: z.string(),
   endYear: z.string(),
   sessions: z.array(
     z.strictObject({
-      chamber: z.string(),
-      type: z.string(),
-      number: z.number(),
+      chamber: z.nativeEnum(CongressChamber),
+      type: z.nativeEnum(Session),
+      number: z.number().optional(),
       startDate: z.string(),
       endDate: z.string().optional(),
     }),
@@ -24,8 +26,8 @@ export const CongressSchema = z.strictObject({
   endYear: z.string(),
   sessions: z.array(
     z.strictObject({
-      chamber: z.string(),
-      type: z.string(),
+      chamber: z.nativeEnum(CongressChamber),
+      type: z.nativeEnum(Session),
       number: z.number(),
       startDate: z.string(),
       endDate: z.string().optional(),
@@ -34,5 +36,6 @@ export const CongressSchema = z.strictObject({
   url: z.string(),
   updateDate: z.string(),
 });
-export type ListCongress = z.infer<typeof ListCongressSchema>;
+
+export type CongressSummary = z.infer<typeof CongressSummarySchema>;
 export type Congress = z.infer<typeof CongressSchema>;

--- a/src/schemas/constants.ts
+++ b/src/schemas/constants.ts
@@ -13,11 +13,21 @@ export enum AmendmentType {
   SUAMDT = 'SUAMDT', // 97th and 98th Congresses
 }
 
+export enum CongressChamber {
+  HOUSE = 'House',
+  SENATE = 'Senate',
+}
+
 export enum Chamber {
   HOUSE = 'House',
   SENATE = 'Senate',
   JOINT = 'Joint',
   NO_CHAMBER = 'NoChamber',
+}
+
+export enum Session {
+  REGULAR = 'R',
+  SPECIAL = 'S',
 }
 
 export enum ChamberCode {


### PR DESCRIPTION
- Add enums for Congress Chamber and Session.
- Number is made optional because it is not included in special sessions