### PR TITLE
feat: add url search param parsing

### DIFF
--- a/fixtures/nock.json
+++ b/fixtures/nock.json
@@ -3850,5 +3850,41 @@
       "x-vcap-request-id": "068339e4-6a93-4772-47d9-15bb73321297"
     },
     "responseIsBinary": false
+  },
+  {
+    "scope": "https://api.congress.gov:443",
+    "method": "GET",
+    "path": "/v3/bill?limit=5&sort=updateDate%2Bdesc&fromDateTime=2024-01-01T00%3A00%3A00Z&toDateTime=2024-12-31T00%3A00%3A00Z",
+    "body": "",
+    "status": 200,
+    "response": [
+      "1f8b0800000000000013ed97db6edb461086eff314035e182d608a0749d10130025746e2226d13586a2f5af4624c8ea88d97bbecee508d1ae4dd8b59c98e2c9fe41a6d5da08200519a7f9633fb7f1a929f5e000044e74a6b1f8de197f0555e9fae8e82a0b0a672e445331c1c5e8f6964f27c5cb0b2261aef64060586d80932456388b2d1cb3c4e7b713e880e6f6a993eb2a8bea1026b82f7edb956057c87bfc30fb603c341dcebf5a36b699f77ea316d7d4e2e9ca93f1ced9c23b24e55ca4c1678299a9291c2ee934d6c192a9feeaa58b10e916303c705035bc09a4c09bc2098d8ba6e8d2a509af7216ee7908dbabda06b79619dfa83825679dfa22948140e4b65c136e490ad03ad0a329ebc2499b0166a2f3ac9fbd128a612a62c1edca86ed5dc5e76db94c874e9479ee6bd38cde27478b7ee5b53e8b654a69a6decb927c969112c981b3f4e126c54e7929e4e6597c9b29b086ec97090f8441c7a35b7ae463efae0adf9e2ec96ab77b3384a9fcee220cef238eb3d9ec5511a67a397fbb298e783fe832c9edad6ef87e2e94328cead0b8438d28ae6c2cb89ebc0992ad095167e42ade9838529d6a811be425342e3ec52951432279b3d0eb481a3527976aa6065aaafefc2ecf46c3fceb2ee5fe0ec96a43d391ba5c9c225b2fd4f002dcbf2279296a7591ea7fd384bef23ed8ce6e41c95f26717f7a6ed7961eb5a31138135f0860c39d4f01a5d1d068c2d152bf220069e297f01dfa3c18a6a32dcd917cd5eafbf3b8aff1e3467161cfdd62a47570352ea5fc1eb965b471e6632fb4c15222ad01736022f080a728ccac07a57c3347454b605017d2c84d425816fa868759891a00cc85e552ba8d15d10fbced3b815f31ecdedad497b729b65b9802be63c0370f39b931e1e03ee0935e858b08477e1ca26261ec2bb2539afaa051f0682273269f607b73b18fc83e07aab9704e1b770bd260fca2cad5e0ab18e50cb046dc8f12af422a037a1612c02f325b45ea4f3d694fe72da96d09a92d6a3fa58a3bf4078abb48113b712ed1b8786e1bdb395c3fa3f4ab0b8f40c087e9ea3b73bcafe1fbdb702f9ef832be6dc016e38fa75bd7cd460a5d677e6d7688c0adb1aa9284bfbbd74eba929329b4a1f2ae495b78e8fbeb47a3077b6968399aae9e8ea163c9ba5e938bc7f3e607b3d9ee571773b6ee7734f7cd43fd0aa56f279a3bf0dac91e0429e775b324c86671bffb069f4e60127092b6c35b95e58545b6bbff8fc2725de9c87720e0000"
+    ],
+    "rawHeaders": {
+      "access-control-allow-origin": "*",
+      "age": "1",
+      "cache-control": "max-age=900",
+      "cf-cache-status": "DYNAMIC",
+      "cf-ray": "953516d5abe2fef9-PDX",
+      "connection": "keep-alive",
+      "content-encoding": "gzip",
+      "content-type": "application/json",
+      "date": "Sat, 21 Jun 2025 17:05:11 GMT",
+      "expires": "Sat, 21 Jun 2025 17:20:11 GMT",
+      "link": "<https://api.congress.gov/v3/bill>; rel=\"canonical\"",
+      "set-cookie": "__cf_bm=Dq7Q5SX6NuAFfm9a2B0I464YRlrrzrivOfapIInryxs-1750525511-1.0.1.1-Mten_4YjszQ5fj_.pVdskAZkZoQ5hnKnc6yfmdaM.On42q3XGmllm.VkaENzBg7JlT.QAbqIQoYdwTsNJtcNMJRZpVFGJetRFgMflgbPDic; path=/; expires=Sat, 21-Jun-25 17:35:11 GMT; domain=.congress.gov; HttpOnly",
+      "strict-transport-security": "max-age=31536000; preload",
+      "transfer-encoding": "chunked",
+      "vary": "Accept-Encoding, Accept",
+      "via": "https/1.1 api-umbrella (ApacheTrafficServer [cMsSf ])",
+      "x-api-umbrella-request-id": "cnidpo30qoecv0vj3ds0",
+      "x-cache": "MISS",
+      "x-content-type-options": "nosniff",
+      "x-frame-options": "DENY",
+      "x-ratelimit-limit": "30",
+      "x-ratelimit-remaining": "28",
+      "x-vcap-request-id": "92670cfc-fd25-449d-567e-378542a01ea2"
+    },
+    "responseIsBinary": false
   }
 ]

--- a/scripts/updateNocks.ts
+++ b/scripts/updateNocks.ts
@@ -5,7 +5,7 @@ import { CongressDotGovClient } from '../src/congress-dot-gov';
 import { AmendmentType, BillType, Chamber, CommitteeReportType, CommunicationTypeCode, LawType } from '../src/schemas/constants';
 
 const fixturesDir = path.join(__dirname, '..', 'fixtures');
-const fixturePath = path.join(fixturesDir, 'nock.json')
+const fixturePath = path.join(fixturesDir, 'dnock.json')
 
 const API_KEY = process.env.CONGRESS_GOV_API_KEY as string;
 
@@ -30,6 +30,7 @@ const main = async () => {
     client.amendment.getAmendmentText(117, AmendmentType.SAMDT, '1'),
     // Bill
     client.bill.getBills({ limit: 5 }),
+    client.bill.getBills({ limit: 5, sort: 'updateDate+desc', fromDateTime: new Date('2024-01-01'), toDateTime: new Date('2024-12-31') }),
     client.bill.getBillsByCongress(117, { limit: 5 }),
     client.bill.getBillsByCongressAndType(117, BillType.HR, { limit: 5 }),
     client.bill.getBill(117, BillType.HR, '1'),

--- a/src/clients/base.test.ts
+++ b/src/clients/base.test.ts
@@ -1,5 +1,6 @@
-import { BaseClient } from './base';
+import { BaseClient, CongressGovURLSearchParams } from './base';
 import { RateLimitExceededError, CongressGovApiError } from '../utils/errors';
+import { Format } from '../types';
 
 let fetchSpy: jest.SpyInstance;
 
@@ -25,6 +26,44 @@ describe('BaseClient', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  describe('CongressGovURLSearchParams', () => {
+    it('should convert params object to URLSearchParams', () => {
+      const params = {
+        limit: 20,
+        offset: 0,
+        format: Format.JSON
+      };
+
+      const searchParams = new CongressGovURLSearchParams(params);
+      expect(searchParams.toUrlSearchParams()).toBe('limit=20&offset=0&format=json');
+    });
+
+    it('should handle empty params object', () => {
+      const searchParams = new CongressGovURLSearchParams({});
+      expect(searchParams.toUrlSearchParams()).toBe('');
+    });
+
+    it('should handle params with undefined values', () => {
+      const params = {
+        limit: 20,
+        format: undefined
+      };
+
+      const searchParams = new CongressGovURLSearchParams(params);
+      expect(searchParams.toUrlSearchParams()).toBe('limit=20');
+    });
+
+    it('should handle date params', () => { 
+      const params = {
+        fromDateTime: new Date('2021-01-01'),
+        toDateTime: new Date('2021-12-31')
+      };
+
+      const searchParams = new CongressGovURLSearchParams(params);
+      expect(searchParams.toUrlSearchParams()).toBe('fromDateTime=2021-01-01T00%3A00%3A00Z&toDateTime=2021-12-31T00%3A00%3A00Z');
+    });
   });
 
   describe('Constructor', () => {

--- a/src/clients/bill.test.ts
+++ b/src/clients/bill.test.ts
@@ -36,6 +36,13 @@ describe('BillClient Tests', () => {
         expect(ListBillSchema.parse(bill));
       });
     });
+
+    it('should query by date range', async () => {
+      const { bills } = await client.getBills({ limit: 5, sort: 'updateDate+desc', fromDateTime: new Date('2024-01-01'), toDateTime: new Date('2024-12-31') });
+
+      expect(Array.isArray(bills)).toBe(true);
+      expect(bills.length).toBeLessThanOrEqual(5);
+    });
   });
 
   describe('getBillByCongress', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,9 @@ export interface PaginationParams extends BaseParams {
 
 export interface DateFilterParams {
   // The starting timestamp to filter by update date. Use format: YYYY-MM-DDT00:00:00Z.
-  fromDateTime?: string;
+  fromDateTime?: string | Date;
   // The ending timestamp to filter by update date. Use format: YYYY-MM-DDT00:00:00Z.
-  toDateTime?: string;
+  toDateTime?: string | Date;
 }
 
 export interface SortParams {


### PR DESCRIPTION
Adding better URL search param parsing allows for parsing dates and strings to the correct format required by the api. The required format is not supported by the standard Javascript library so by abstracting this away we can hide this complexity from consumers