### PR TITLE
refactor: narrow types accepted by sort param

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface DateFilterParams {
 
 export interface SortParams {
   // The field to sort by.
-  sort?: string;
+  sort?: 'updateDate+asc' | 'updateDate+desc';
 }
 
 export interface BasePaginatedResponse {


### PR DESCRIPTION
Sort param only accepts 'updateDate+asc' or 'updateDate+desc'.